### PR TITLE
Update README with imagePath usage note

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ const styles = StyleSheet.create({
 | `onCanUndoChanged` | `(event: NativeEvent<CanUndoChangedEvent>) => void` | Called when undo state changes   |
 | `onCanRedoChanged` | `(event: NativeEvent<CanRedoChangedEvent>) => void` | Called when redo state changes   |
 
+_Note:_ When using `imagePath` with local assets, such as those served from `./assets/` using `require()`, the asset source must be resolved using [`resolveAssetSource()`](https://reactnative.dev/docs/image#resolveassetsource) before passing the URI to the prop. 
+
 #### Ref Methods
 
 | Method                     | Parameters        | Return Type        | Description                             |


### PR DESCRIPTION
This pull request adds a helpful note to the documentation in `README.md` to clarify how to use the `imagePath` prop with local assets. The note explains that local asset sources must be resolved using `resolveAssetSource()` before passing the URI to the prop, which will help prevent common issues when working with images in React Native. 

* Documentation update: Added a note to the `README.md` explaining the need to use `resolveAssetSource()` when passing local asset URIs to the `imagePath` prop.